### PR TITLE
Fix: Solved Cart Animation Transition

### DIFF
--- a/src/css/utils/transitions.scss
+++ b/src/css/utils/transitions.scss
@@ -26,7 +26,7 @@
 
 .slide-mobile-menu-enter-from,
 .slide-mobile-menu-leave-to {
-  @apply translate-x-full transform opacity-0;
+  @apply -translate-x-full transform opacity-0;
 }
 
 /**


### PR DESCRIPTION
# PR Summary

Cart animation should start from left instead of starting from the right side.