### PR TITLE
Hotfix: Variant radio button wasn't clickable, now it is

### DIFF
--- a/snippets/helper-product-config.liquid
+++ b/snippets/helper-product-config.liquid
@@ -44,8 +44,8 @@
   {%- endfor -%}
   ], options: [
   {%- for option in prod.options_with_values -%}
-    { name: {{ option.name | json | replace: '"', "'" }}, position: {{ option.position | json | replace: '"', "'" }},
-    value: [
+    { name: {{ option.name | handle | json | replace: '"', "'" }}, position:
+    {{ option.position | json | replace: '"', "'" }}, value: [
     {%- for value in option.values -%}
       {{ value | url_encode | json | replace: '"', "'" }}
       {%- unless forloop.last %},{% endunless %}

--- a/snippets/product-form.liquid
+++ b/snippets/product-form.liquid
@@ -24,13 +24,34 @@
                 :class="
                   {
                     'hidden': !isVisibleOption({
-                      type: '{{ option.name | downcase }}',
+                      type: '{{ option.name | handle }}',
                       value: '{{ value | url_encode }}',
                       position: {{ option.position }}
                     })
                   }
                 "
               >
+                <input
+                  {% comment %} class="sr-only" {% endcomment %}
+                  type="radio"
+                  id="{{ name | handle }}"
+                  name="{{ option.name | handle }}"
+                  title="Select {{ value }} for {{ option.name }}"
+                  :checked="
+                    isActiveOption({
+                      type: '{{ option.name | handle }}',
+                      value: '{{ value | url_encode }}',
+                      position: {{ option.position }}
+                    })
+                  "
+                  @change="
+                    findVariantsByOptions({
+                      type: '{{ option.name | handleize }}',
+                      value: '{{ value | url_encode}}',
+                      position: {{ option.position }}
+                    })
+                  "
+                >
                 <label
                   for="{{ name | handle }}"
                   @click.prevent="
@@ -50,21 +71,6 @@
                     }
                   "
                 >
-                  <input
-                    {% comment %} class="sr-only" {% endcomment %}
-                    type="radio"
-                    id="{{ name | handle }}"
-                    name="{{ option.name | downcase }}"
-                    title="Select {{ value }} for {{ option.name }}"
-                    :checked="
-                      isActiveOption({
-                        type: '{{ option.name | handle }}',
-                        value: '{{ value | url_encode }}',
-                        position: {{ option.position }}
-                      })
-                    "
-                  >
-
                   <span>{{ value }}</span>
                 </label>
               </li>

--- a/src/vue/components/ProductOptions/index.vue
+++ b/src/vue/components/ProductOptions/index.vue
@@ -29,7 +29,7 @@ const {
   findVariantsByOptions,
   isVisibleOption,
   isActiveOption,
-} = useProductOptions(storeProduct.value, storeVariant.value);
+} = useProductOptions(storeProduct.value, storeVariant.value.id);
 
 const updateProductUrl = (product, variant) => {
   const url =


### PR DESCRIPTION
# PR Summary

Variants radio wasn't clickable.

## Checklist:

- [x] Added PR summary for [release notes](https://themes.shopify.com/themes/dawn/styles/default#ReleaseNotes)
- [x] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [x] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [x] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [x] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [x] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)